### PR TITLE
Fix on navbar for curentPageNode

### DIFF
--- a/bootstrap4-components/src/main/resources/bootstrap4nt_navbar/html/navbar.basenav.jsp
+++ b/bootstrap4-components/src/main/resources/bootstrap4nt_navbar/html/navbar.basenav.jsp
@@ -20,7 +20,7 @@
     <c:set var="recursive" value="true"/>
 </c:if>
 <c:set var="root" value="${currentNode.properties.root.string}"/>
-<c:set var="curentPageNode" value="${jcr:getMeAndParentsOfType(renderContext.mainResource.node,'jnt:page')}"/>
+<c:set var="curentPageNode" value="${renderContext.mainResource.node}"/>
 <c:choose>
     <c:when test="${root eq 'currentPage'}">
         <c:set var="rootNode" value="${curentPageNode}"/>

--- a/bootstrap4-components/src/main/resources/bootstrap4nt_navbar/html/navbar.jsp
+++ b/bootstrap4-components/src/main/resources/bootstrap4nt_navbar/html/navbar.jsp
@@ -50,8 +50,8 @@
 </c:if>
 
 <c:set var="root" value="${currentNode.properties.root.string}"/>
-<c:set var="curentPageNode" value="${jcr:getMeAndParentsOfType(renderContext.mainResource.node,'jnt:page')}"/>
-<%-- FIXME this rerutn a list instead of a node --> currentPage and parentPage won't work --%>
+
+<c:set var="curentPageNode" value="${renderContext.mainResource.node}"/>
 <c:choose>
     <c:when test="${root eq 'currentPage'}">
         <c:set var="rootNode" value="${curentPageNode}"/>


### PR DESCRIPTION
### Steps to reproduce
Create a nav menu on 1st level (siblings of the home) and choose 'currentPage' or 'parentPage' as root page

### Expected behavior
This should display the menu

### Actual behavior
This generates an issue as described on #2 

### System configuration
**DX version**:
7.3.3.0

**Bootstrap 4 for DX version**:
2.2.0