### PR TITLE
QA-13562 Prevent NavBar exception on Studio (in-context mode)

### DIFF
--- a/bootstrap4-components/src/main/resources/bootstrap4nt_navbar/html/navbar.jsp
+++ b/bootstrap4-components/src/main/resources/bootstrap4nt_navbar/html/navbar.jsp
@@ -85,11 +85,18 @@
         <div class="container">
     </c:if>
     <c:choose>
-        <c:when test="${jcr:isNodeType(rootNode, 'jnt:virtualsite')}">
-            <c:url var="rootNodeUrl" value="${renderContext.site.home.url}"/>
+        <c:when test="${fn:startsWith(currentNode.path,'/modules') || renderContext.editModeConfigName eq 'studiomode'}">
+            <c:url var="rootNodeUrl" value="${rootNode.url}"/>
         </c:when>
         <c:otherwise>
-            <c:url var="rootNodeUrl" value="${rootNode.url}"/>
+            <c:choose>
+                <c:when test="${jcr:isNodeType(rootNode, 'jnt:virtualsite')}">
+                    <c:url var="rootNodeUrl" value="${renderContext.site.home.url}"/>
+                </c:when>
+                <c:otherwise>
+                    <c:url var="rootNodeUrl" value="${rootNode.url}"/>
+                </c:otherwise>
+            </c:choose>
         </c:otherwise>
     </c:choose>
 


### PR DESCRIPTION
### Jira

https://jira.jahia.org/browse/QA-13562

### Steps to reproduce
Add a navbar on the studio
Switch to in-context mode

### Expected behavior
The navbar should be visible

### Actual behavior
A trace is displayed on the Studio
```
javax.el.ELException: Problems calling function [jcr:isNodeType]
```

### System configuration
**DX version**: 8.0.1.0

**Bootstrap 4 for DX version**: 4.6.0
