### PR TITLE
refactor: de-duplicate choice-list initializers, fix Sonar, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Code Quality
+
+- Extracted a shared `AbstractChoiceListInitializerRenderer` base class for the `ButtonType`, `NavbarRoot`, and `GridType` choice-list initializers, which were ~90% duplicated (project duplication dropped from 32% to 0%). Removed unused `logger` fields, applied the diamond operator, and extracted the repeated `addMixin` literal to a constant.
+- `SwitchToLanguageTag` — removed a `languageCode` field that shadowed the inherited `AbstractJahiaTag.languageCode` (SonarQube BLOCKER) and added the missing `@Override` annotations.
+
+### Tests
+
+- Added the first unit tests for `bootstrap4-components` (JUnit 4 + Mockito, 16 tests) covering the three choice-list initializers and the `Functions` taglib helper, with JaCoCo coverage wiring.
+
 ## [4.7.0] - 2026-05-27
 
 ### Breaking Changes

--- a/bootstrap4-components/pom.xml
+++ b/bootstrap4-components/pom.xml
@@ -34,12 +34,25 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     <version.compiler.plugin>3.13.0</version.compiler.plugin>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
   <dependencies>
     <dependency>
       <groupId>javax.servlet.jsp</groupId>
       <artifactId>jsp-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.12.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
@@ -67,6 +80,26 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.12</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/initializers/AbstractChoiceListInitializerRenderer.java
+++ b/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/initializers/AbstractChoiceListInitializerRenderer.java
@@ -1,0 +1,97 @@
+package org.jahia.modules.bootstrap4.initializers;
+
+import org.jahia.services.content.JCRPropertyWrapper;
+import org.jahia.services.content.nodetypes.ExtendedPropertyDefinition;
+import org.jahia.services.content.nodetypes.ValueImpl;
+import org.jahia.services.content.nodetypes.initializers.ChoiceListValue;
+import org.jahia.services.content.nodetypes.initializers.ModuleChoiceListInitializer;
+import org.jahia.services.content.nodetypes.renderer.AbstractChoiceListRenderer;
+import org.jahia.services.content.nodetypes.renderer.ModuleChoiceListRenderer;
+import org.jahia.services.render.RenderContext;
+
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Base class for the Bootstrap 4 module choice list initializers/renderers.
+ * <p>
+ * Holds the members shared by all concrete initializers: the {@code key} property
+ * (with its accessors) and both {@code getStringRendering} implementations, plus a
+ * helper to build {@link ChoiceListValue} entries.
+ */
+public abstract class AbstractChoiceListInitializerRenderer extends AbstractChoiceListRenderer
+        implements ModuleChoiceListInitializer, ModuleChoiceListRenderer {
+
+    protected static final String ADD_MIXIN = "addMixin";
+
+    private String key;
+
+    protected AbstractChoiceListInitializerRenderer(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Builds a {@link ChoiceListValue} for the given value name, optionally attaching
+     * an {@code addMixin} property pointing to the supplied mixin type.
+     *
+     * @param value the choice value name (used both as display name and stored value)
+     * @param mixin the mixin to add when this value is selected, or {@code null} for none
+     * @return the assembled choice list value
+     */
+    protected ChoiceListValue buildChoiceListValue(String value, String mixin) {
+        Map<String, Object> properties = new HashMap<>();
+        if (mixin != null) {
+            properties.put(ADD_MIXIN, mixin);
+        }
+        return new ChoiceListValue(value, properties, new ValueImpl(value, PropertyType.STRING, false));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getStringRendering(RenderContext context, JCRPropertyWrapper propertyWrapper) throws RepositoryException {
+        final StringBuilder sb = new StringBuilder();
+
+        if (propertyWrapper.isMultiple()) {
+            sb.append('{');
+            final Value[] values = propertyWrapper.getValues();
+            for (Value value : values) {
+                sb.append('[').append(value.getString()).append(']');
+            }
+            sb.append('}');
+        } else {
+            sb.append('[').append(propertyWrapper.getValue().getString()).append(']');
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getStringRendering(Locale locale, ExtendedPropertyDefinition propDef, Object propertyValue) throws RepositoryException {
+        return "[" + propertyValue.toString() + "]";
+    }
+}

--- a/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/initializers/ButtonTypeInitializer.java
+++ b/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/initializers/ButtonTypeInitializer.java
@@ -1,116 +1,42 @@
 package org.jahia.modules.bootstrap4.initializers;
 
-/**
- * Created by pol on 21.02.17.
- */
-import org.jahia.services.content.JCRPropertyWrapper;
 import org.jahia.services.content.nodetypes.ExtendedPropertyDefinition;
-import org.jahia.services.content.nodetypes.ValueImpl;
 import org.jahia.services.content.nodetypes.initializers.ChoiceListValue;
 import org.jahia.services.content.nodetypes.initializers.ModuleChoiceListInitializer;
-import org.jahia.services.content.nodetypes.renderer.AbstractChoiceListRenderer;
-import org.jahia.services.content.nodetypes.renderer.ModuleChoiceListRenderer;
-import org.jahia.services.render.RenderContext;
 import org.osgi.service.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 @Component(name = "buttonTypeInitializer", service = ModuleChoiceListInitializer.class, immediate = true)
-public class ButtonTypeInitializer extends AbstractChoiceListRenderer implements ModuleChoiceListInitializer, ModuleChoiceListRenderer {
+public class ButtonTypeInitializer extends AbstractChoiceListInitializerRenderer {
 
-    private static final Logger logger = LoggerFactory.getLogger(ButtonTypeInitializer.class);
-
-    private String key = "buttonTypeInitializer";
+    public ButtonTypeInitializer() {
+        super("buttonTypeInitializer");
+    }
 
     /**
      * {@inheritDoc}
      */
+    @Override
     public List<ChoiceListValue> getChoiceListValues(ExtendedPropertyDefinition epd, String param, List<ChoiceListValue> values,
                                                      Locale locale, Map<String, Object> context) {
 
-        //Create the list of ChoiceListValue to return
-        List<ChoiceListValue> myChoiceList = new ArrayList<ChoiceListValue>();
+        // Create the list of ChoiceListValue to return
+        List<ChoiceListValue> myChoiceList = new ArrayList<>();
 
         if (context == null) {
             return myChoiceList;
         }
 
-        HashMap<String, Object> myPropertiesMap = null;
+        myChoiceList.add(buildChoiceListValue("externalLink", "bootstrap4mix:externalLink"));
+        myChoiceList.add(buildChoiceListValue("internalLink", "bootstrap4mix:internalLink"));
+        myChoiceList.add(buildChoiceListValue("modal", "bootstrap4mix:modal"));
+        myChoiceList.add(buildChoiceListValue("collapse", "bootstrap4mix:collapse"));
+        myChoiceList.add(buildChoiceListValue("popover", "bootstrap4mix:popover"));
 
-
-        //externalLink
-        myPropertiesMap = new HashMap<String, Object>();
-        myPropertiesMap.put("addMixin","bootstrap4mix:externalLink");
-        myChoiceList.add(new ChoiceListValue("externalLink",myPropertiesMap,new ValueImpl("externalLink", PropertyType.STRING, false)));
-
-        //internalLink
-        myPropertiesMap = new HashMap<String, Object>();
-        myPropertiesMap.put("addMixin","bootstrap4mix:internalLink");
-        myChoiceList.add(new ChoiceListValue("internalLink",myPropertiesMap,new ValueImpl("internalLink", PropertyType.STRING, false)));
-
-        //modal
-        myPropertiesMap = new HashMap<String, Object>();
-        myPropertiesMap.put("addMixin","bootstrap4mix:modal");
-        myChoiceList.add(new ChoiceListValue("modal",myPropertiesMap,new ValueImpl("modal", PropertyType.STRING, false)));
-
-        //modal
-        myPropertiesMap = new HashMap<String, Object>();
-        myPropertiesMap.put("addMixin","bootstrap4mix:collapse");
-        myChoiceList.add(new ChoiceListValue("collapse",myPropertiesMap,new ValueImpl("collapse", PropertyType.STRING, false)));
-
-        //popover
-        myPropertiesMap = new HashMap<String, Object>();
-        myPropertiesMap.put("addMixin","bootstrap4mix:popover");
-        myChoiceList.add(new ChoiceListValue("popover",myPropertiesMap,new ValueImpl("popover", PropertyType.STRING, false)));
-
-        //Return the list
         return myChoiceList;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getKey() {
-        return key;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getStringRendering(RenderContext context, JCRPropertyWrapper propertyWrapper) throws RepositoryException {
-        final StringBuilder sb = new StringBuilder();
-
-        if (propertyWrapper.isMultiple()) {
-            sb.append('{');
-            final Value[] values = propertyWrapper.getValues();
-            for (Value value : values) {
-                sb.append('[').append(value.getString()).append(']');
-            }
-            sb.append('}');
-        } else {
-            sb.append('[').append(propertyWrapper.getValue().getString()).append(']');
-        }
-
-        return sb.toString();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getStringRendering(Locale locale, ExtendedPropertyDefinition propDef, Object propertyValue) throws RepositoryException {
-        return "[" + propertyValue.toString() + "]";
-    }
 }
-

--- a/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/initializers/GridTypeInitializer.java
+++ b/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/initializers/GridTypeInitializer.java
@@ -1,104 +1,40 @@
 package org.jahia.modules.bootstrap4.initializers;
 
-/**
- * Created by pol on 21.02.17.
- */
-import org.jahia.services.content.JCRPropertyWrapper;
 import org.jahia.services.content.nodetypes.ExtendedPropertyDefinition;
-import org.jahia.services.content.nodetypes.ValueImpl;
 import org.jahia.services.content.nodetypes.initializers.ChoiceListValue;
 import org.jahia.services.content.nodetypes.initializers.ModuleChoiceListInitializer;
-import org.jahia.services.content.nodetypes.renderer.AbstractChoiceListRenderer;
-import org.jahia.services.content.nodetypes.renderer.ModuleChoiceListRenderer;
-import org.jahia.services.render.RenderContext;
 import org.osgi.service.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 @Component(name = "gridTypeInitializer", service = ModuleChoiceListInitializer.class, immediate = true)
-public class GridTypeInitializer extends AbstractChoiceListRenderer implements ModuleChoiceListInitializer, ModuleChoiceListRenderer {
+public class GridTypeInitializer extends AbstractChoiceListInitializerRenderer {
 
-    private static final Logger logger = LoggerFactory.getLogger(GridTypeInitializer.class);
-
-    private String key = "gridTypeInitializer";
+    public GridTypeInitializer() {
+        super("gridTypeInitializer");
+    }
 
     /**
      * {@inheritDoc}
      */
+    @Override
     public List<ChoiceListValue> getChoiceListValues(ExtendedPropertyDefinition epd, String param, List<ChoiceListValue> values,
                                                      Locale locale, Map<String, Object> context) {
 
-        //Create the list of ChoiceListValue to return
-        List<ChoiceListValue> myChoiceList = new ArrayList<ChoiceListValue>();
+        // Create the list of ChoiceListValue to return
+        List<ChoiceListValue> myChoiceList = new ArrayList<>();
 
         if (context == null) {
             return myChoiceList;
         }
 
-        HashMap<String, Object> myPropertiesMap = null;
+        myChoiceList.add(buildChoiceListValue("nogrid", null));
+        myChoiceList.add(buildChoiceListValue("predefinedGrid", "bootstrap4mix:predefinedGrid"));
+        myChoiceList.add(buildChoiceListValue("customGrid", "bootstrap4mix:customGrid"));
 
-        // nogrid
-        myPropertiesMap = new HashMap<String, Object>();
-        myChoiceList.add(new ChoiceListValue("nogrid",myPropertiesMap,new ValueImpl("nogrid", PropertyType.STRING, false)));
-
-        //predefined
-        myPropertiesMap = new HashMap<String, Object>();
-        myPropertiesMap.put("addMixin","bootstrap4mix:predefinedGrid");
-        myChoiceList.add(new ChoiceListValue("predefinedGrid",myPropertiesMap,new ValueImpl("predefinedGrid", PropertyType.STRING, false)));
-
-        //custom
-        myPropertiesMap = new HashMap<String, Object>();
-        myPropertiesMap.put("addMixin","bootstrap4mix:customGrid");
-        myChoiceList.add(new ChoiceListValue("customGrid",myPropertiesMap,new ValueImpl("customGrid", PropertyType.STRING, false)));
-
-        //Return the list
         return myChoiceList;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getKey() {
-        return key;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getStringRendering(RenderContext context, JCRPropertyWrapper propertyWrapper) throws RepositoryException {
-        final StringBuilder sb = new StringBuilder();
-
-        if (propertyWrapper.isMultiple()) {
-            sb.append('{');
-            final Value[] values = propertyWrapper.getValues();
-            for (Value value : values) {
-                sb.append('[').append(value.getString()).append(']');
-            }
-            sb.append('}');
-        } else {
-            sb.append('[').append(propertyWrapper.getValue().getString()).append(']');
-        }
-
-        return sb.toString();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getStringRendering(Locale locale, ExtendedPropertyDefinition propDef, Object propertyValue) throws RepositoryException {
-        return "[" + propertyValue.toString() + "]";
-    }
 }
-

--- a/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/initializers/NavbarRootInitializer.java
+++ b/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/initializers/NavbarRootInitializer.java
@@ -1,107 +1,41 @@
 package org.jahia.modules.bootstrap4.initializers;
 
-/**
- * Created by pol on 21.02.17.
- */
-import org.jahia.services.content.JCRPropertyWrapper;
 import org.jahia.services.content.nodetypes.ExtendedPropertyDefinition;
-import org.jahia.services.content.nodetypes.ValueImpl;
 import org.jahia.services.content.nodetypes.initializers.ChoiceListValue;
 import org.jahia.services.content.nodetypes.initializers.ModuleChoiceListInitializer;
-import org.jahia.services.content.nodetypes.renderer.AbstractChoiceListRenderer;
-import org.jahia.services.content.nodetypes.renderer.ModuleChoiceListRenderer;
-import org.jahia.services.render.RenderContext;
 import org.osgi.service.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.jcr.PropertyType;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 @Component(name = "navbarRootInitializer", service = ModuleChoiceListInitializer.class, immediate = true)
-public class NavbarRootInitializer extends AbstractChoiceListRenderer implements ModuleChoiceListInitializer, ModuleChoiceListRenderer {
+public class NavbarRootInitializer extends AbstractChoiceListInitializerRenderer {
 
-    private static final Logger logger = LoggerFactory.getLogger(NavbarRootInitializer.class);
-
-    private String key = "navbarRootInitializer";
+    public NavbarRootInitializer() {
+        super("navbarRootInitializer");
+    }
 
     /**
      * {@inheritDoc}
      */
+    @Override
     public List<ChoiceListValue> getChoiceListValues(ExtendedPropertyDefinition epd, String param, List<ChoiceListValue> values,
                                                      Locale locale, Map<String, Object> context) {
 
-        //Create the list of ChoiceListValue to return
-        List<ChoiceListValue> myChoiceList = new ArrayList<ChoiceListValue>();
+        // Create the list of ChoiceListValue to return
+        List<ChoiceListValue> myChoiceList = new ArrayList<>();
 
         if (context == null) {
             return myChoiceList;
         }
 
-        HashMap<String, Object> myPropertiesMap = null;
+        myChoiceList.add(buildChoiceListValue("homePage", null));
+        myChoiceList.add(buildChoiceListValue("currentPage", null));
+        myChoiceList.add(buildChoiceListValue("parentPage", null));
+        myChoiceList.add(buildChoiceListValue("customRootPage", "bootstrap4mix:customRootPage"));
 
-        //homePage
-        myPropertiesMap = new HashMap<String, Object>();
-        myChoiceList.add(new ChoiceListValue("homePage",myPropertiesMap,new ValueImpl("homePage", PropertyType.STRING, false)));
-
-        //currentPage
-        myPropertiesMap = new HashMap<String, Object>();
-        myChoiceList.add(new ChoiceListValue("currentPage",myPropertiesMap,new ValueImpl("currentPage", PropertyType.STRING, false)));
-
-        //parentPage
-        myPropertiesMap = new HashMap<String, Object>();
-        myChoiceList.add(new ChoiceListValue("parentPage",myPropertiesMap,new ValueImpl("parentPage", PropertyType.STRING, false)));
-
-        //customRootPage
-        myPropertiesMap = new HashMap<String, Object>();
-        myPropertiesMap.put("addMixin","bootstrap4mix:customRootPage");
-        myChoiceList.add(new ChoiceListValue("customRootPage",myPropertiesMap,new ValueImpl("customRootPage", PropertyType.STRING, false)));
-
-        //Return the list
         return myChoiceList;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public void setKey(String key) {
-        this.key = key;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getKey() {
-        return key;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getStringRendering(RenderContext context, JCRPropertyWrapper propertyWrapper) throws RepositoryException {
-        final StringBuilder sb = new StringBuilder();
-
-        if (propertyWrapper.isMultiple()) {
-            sb.append('{');
-            final Value[] values = propertyWrapper.getValues();
-            for (Value value : values) {
-                sb.append('[').append(value.getString()).append(']');
-            }
-            sb.append('}');
-        } else {
-            sb.append('[').append(propertyWrapper.getValue().getString()).append(']');
-        }
-
-        return sb.toString();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String getStringRendering(Locale locale, ExtendedPropertyDefinition propDef, Object propertyValue) throws RepositoryException {
-        return "[" + propertyValue.toString() + "]";
-    }
 }
-

--- a/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/taglibs/SwitchToLanguageTag.java
+++ b/bootstrap4-components/src/main/java/org/jahia/modules/bootstrap4/taglibs/SwitchToLanguageTag.java
@@ -1,23 +1,18 @@
 package org.jahia.modules.bootstrap4.taglibs;
+
 import java.io.IOException;
 import java.util.Locale;
+
 import org.jahia.taglibs.AbstractJahiaTag;
 import org.jahia.utils.LanguageCodeConverters;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class SwitchToLanguageTag extends AbstractJahiaTag {
 
-    private static final transient Logger logger = org.slf4j.LoggerFactory.getLogger(SwitchToLanguageTag.class);
+    private static final transient Logger logger = LoggerFactory.getLogger(SwitchToLanguageTag.class);
 
-    private String languageCode;
-
-    public String getLanguageCode() {
-        return languageCode;
-    }
-
-    public void setLanguageCode(String languageCode) {
-        this.languageCode = languageCode;
-    }
-
+    @Override
     public int doStartTag() {
         try {
             final StringBuilder buff = new StringBuilder(300);

--- a/bootstrap4-components/src/test/java/org/jahia/modules/bootstrap4/FunctionsTest.java
+++ b/bootstrap4-components/src/test/java/org/jahia/modules/bootstrap4/FunctionsTest.java
@@ -1,0 +1,23 @@
+package org.jahia.modules.bootstrap4;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FunctionsTest {
+
+    @Test
+    public void replaceAllReplacesEveryMatch() {
+        assertEquals("a-b-c", Functions.replaceAll("a b c", " ", "-"));
+    }
+
+    @Test
+    public void replaceAllSupportsRegexPatterns() {
+        assertEquals("abc", Functions.replaceAll("a1b2c3", "[0-9]", ""));
+    }
+
+    @Test
+    public void replaceAllReturnsSameStringWhenNoMatch() {
+        assertEquals("hello", Functions.replaceAll("hello", "z", "Z"));
+    }
+}

--- a/bootstrap4-components/src/test/java/org/jahia/modules/bootstrap4/initializers/ButtonTypeInitializerTest.java
+++ b/bootstrap4-components/src/test/java/org/jahia/modules/bootstrap4/initializers/ButtonTypeInitializerTest.java
@@ -1,0 +1,73 @@
+package org.jahia.modules.bootstrap4.initializers;
+
+import org.jahia.services.content.nodetypes.ExtendedPropertyDefinition;
+import org.jahia.services.content.nodetypes.initializers.ChoiceListValue;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jcr.RepositoryException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ButtonTypeInitializerTest {
+
+    private ButtonTypeInitializer initializer;
+
+    @Before
+    public void setUp() {
+        initializer = new ButtonTypeInitializer();
+    }
+
+    @Test
+    public void getChoiceListValuesReturnsExpectedValuesInOrderWithMixins() throws RepositoryException {
+        Map<String, Object> context = new HashMap<>();
+
+        List<ChoiceListValue> result = initializer.getChoiceListValues(null, null, null, Locale.ENGLISH, context);
+
+        assertEquals(5, result.size());
+        assertChoice(result.get(0), "externalLink", "bootstrap4mix:externalLink");
+        assertChoice(result.get(1), "internalLink", "bootstrap4mix:internalLink");
+        assertChoice(result.get(2), "modal", "bootstrap4mix:modal");
+        assertChoice(result.get(3), "collapse", "bootstrap4mix:collapse");
+        assertChoice(result.get(4), "popover", "bootstrap4mix:popover");
+    }
+
+    @Test
+    public void getChoiceListValuesReturnsEmptyListWhenContextIsNull() {
+        List<ChoiceListValue> result = initializer.getChoiceListValues(null, null, null, Locale.ENGLISH, null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void defaultKeyMatchesComponentName() {
+        assertEquals("buttonTypeInitializer", initializer.getKey());
+    }
+
+    @Test
+    public void setKeyOverridesDefaultKey() {
+        initializer.setKey("customKey");
+
+        assertEquals("customKey", initializer.getKey());
+    }
+
+    @Test
+    public void getStringRenderingWrapsValueInBrackets() throws RepositoryException {
+        ExtendedPropertyDefinition propDef = null;
+
+        String rendered = initializer.getStringRendering(Locale.ENGLISH, propDef, "externalLink");
+
+        assertEquals("[externalLink]", rendered);
+    }
+
+    private static void assertChoice(ChoiceListValue choice, String expectedValue, String expectedMixin) throws RepositoryException {
+        assertEquals(expectedValue, choice.getDisplayName());
+        assertEquals(expectedValue, choice.getValue().getString());
+        assertEquals(expectedMixin, choice.getProperties().get("addMixin"));
+    }
+}

--- a/bootstrap4-components/src/test/java/org/jahia/modules/bootstrap4/initializers/GridTypeInitializerTest.java
+++ b/bootstrap4-components/src/test/java/org/jahia/modules/bootstrap4/initializers/GridTypeInitializerTest.java
@@ -1,0 +1,66 @@
+package org.jahia.modules.bootstrap4.initializers;
+
+import org.jahia.services.content.nodetypes.initializers.ChoiceListValue;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jcr.RepositoryException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class GridTypeInitializerTest {
+
+    private GridTypeInitializer initializer;
+
+    @Before
+    public void setUp() {
+        initializer = new GridTypeInitializer();
+    }
+
+    @Test
+    public void getChoiceListValuesReturnsExpectedValuesInOrder() throws RepositoryException {
+        Map<String, Object> context = new HashMap<>();
+
+        List<ChoiceListValue> result = initializer.getChoiceListValues(null, null, null, Locale.ENGLISH, context);
+
+        assertEquals(3, result.size());
+        assertChoice(result.get(0), "nogrid", null);
+        assertChoice(result.get(1), "predefinedGrid", "bootstrap4mix:predefinedGrid");
+        assertChoice(result.get(2), "customGrid", "bootstrap4mix:customGrid");
+    }
+
+    @Test
+    public void getChoiceListValuesReturnsEmptyListWhenContextIsNull() {
+        List<ChoiceListValue> result = initializer.getChoiceListValues(null, null, null, Locale.ENGLISH, null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void defaultKeyMatchesComponentName() {
+        assertEquals("gridTypeInitializer", initializer.getKey());
+    }
+
+    @Test
+    public void getStringRenderingWrapsValueInBrackets() throws RepositoryException {
+        String rendered = initializer.getStringRendering(Locale.ENGLISH, null, "nogrid");
+
+        assertEquals("[nogrid]", rendered);
+    }
+
+    private static void assertChoice(ChoiceListValue choice, String expectedValue, String expectedMixin) throws RepositoryException {
+        assertEquals(expectedValue, choice.getDisplayName());
+        assertEquals(expectedValue, choice.getValue().getString());
+        if (expectedMixin == null) {
+            assertNull(choice.getProperties().get("addMixin"));
+        } else {
+            assertEquals(expectedMixin, choice.getProperties().get("addMixin"));
+        }
+    }
+}

--- a/bootstrap4-components/src/test/java/org/jahia/modules/bootstrap4/initializers/NavbarRootInitializerTest.java
+++ b/bootstrap4-components/src/test/java/org/jahia/modules/bootstrap4/initializers/NavbarRootInitializerTest.java
@@ -1,0 +1,67 @@
+package org.jahia.modules.bootstrap4.initializers;
+
+import org.jahia.services.content.nodetypes.initializers.ChoiceListValue;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jcr.RepositoryException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class NavbarRootInitializerTest {
+
+    private NavbarRootInitializer initializer;
+
+    @Before
+    public void setUp() {
+        initializer = new NavbarRootInitializer();
+    }
+
+    @Test
+    public void getChoiceListValuesReturnsExpectedValuesInOrder() throws RepositoryException {
+        Map<String, Object> context = new HashMap<>();
+
+        List<ChoiceListValue> result = initializer.getChoiceListValues(null, null, null, Locale.ENGLISH, context);
+
+        assertEquals(4, result.size());
+        assertChoice(result.get(0), "homePage", null);
+        assertChoice(result.get(1), "currentPage", null);
+        assertChoice(result.get(2), "parentPage", null);
+        assertChoice(result.get(3), "customRootPage", "bootstrap4mix:customRootPage");
+    }
+
+    @Test
+    public void getChoiceListValuesReturnsEmptyListWhenContextIsNull() {
+        List<ChoiceListValue> result = initializer.getChoiceListValues(null, null, null, Locale.ENGLISH, null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void defaultKeyMatchesComponentName() {
+        assertEquals("navbarRootInitializer", initializer.getKey());
+    }
+
+    @Test
+    public void getStringRenderingWrapsValueInBrackets() throws RepositoryException {
+        String rendered = initializer.getStringRendering(Locale.ENGLISH, null, "homePage");
+
+        assertEquals("[homePage]", rendered);
+    }
+
+    private static void assertChoice(ChoiceListValue choice, String expectedValue, String expectedMixin) throws RepositoryException {
+        assertEquals(expectedValue, choice.getDisplayName());
+        assertEquals(expectedValue, choice.getValue().getString());
+        if (expectedMixin == null) {
+            assertNull(choice.getProperties().get("addMixin"));
+        } else {
+            assertEquals(expectedMixin, choice.getProperties().get("addMixin"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Blind multi-dimensional review of the bootstrap4 module. SonarQube quality gate **was ERROR** (duplicated_lines_density 32.1% vs 3% threshold) and is now **OK** (0%), with 23 issues resolved and the first `bootstrap4-components` unit tests added.

### Code quality / duplication (the gate blocker)
- The three choice-list initializers (`ButtonTypeInitializer`, `NavbarRootInitializer`, `GridTypeInitializer`) were ~90% identical (duplicate `setKey`/`getKey`/`getStringRendering` ×2 plus boilerplate). Extracted a shared `AbstractChoiceListInitializerRenderer` base class; each concrete class now only declares its `@Component`, default key, and its specific choice list via a helper. **Project duplication dropped 32.1% → 0.0%.**
- Removed the unused `logger` fields (S1068), applied the diamond operator (S2293), and extracted the repeated `addMixin` literal to a constant (S1192 CRITICAL).

### Bug / BLOCKER
- `SwitchToLanguageTag` declared a `private String languageCode` field that **shadowed** the inherited `AbstractJahiaTag.languageCode` (Sonar BLOCKER S2387). Verified via `javap` that the superclass exposes a usable `protected` field + accessors; removed the local field and redundant accessors, and added the missing `@Override` annotations (S1161). Rendered `<a>` output is unchanged.

### Tests & coverage
- First unit tests for `bootstrap4-components`: **16 tests** (JUnit 4 + Mockito) covering all three initializers (value names/order, `addMixin` mapping, null-context empty list, string rendering) and the `Functions` taglib helper. JaCoCo coverage wiring.

### Behavior
- No functional change: choice-list values, keys, mixins, and rendering output are identical.

## Test plan
- [x] `mvn clean install` (JDK 17, full reactor) — BUILD SUCCESS, 16/16 tests
- [x] SonarQube gate OK (duplication 0%, 0 open issues)
- N/A Cypress — no E2E harness in this module